### PR TITLE
Support librejs browser plugin.

### DIFF
--- a/public/javascript/about.html
+++ b/public/javascript/about.html
@@ -1,0 +1,224 @@
+<html>
+  <body>
+    <table id="jslicense-labels1">
+      <tr>
+          <td><a href="/javascript/libs/backbone.js">backbone.js</a></td>
+          <td><a href="http://www.jclark.com/xml/copying.txt">MIT license</a></td>
+          <td><a href="/javascript/libs/backbone.js">backbone.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="/javascript/libs/backbone-min.js">backbone-min.js</a></td>
+          <td><a href="http://www.jclark.com/xml/copying.txt">MIT license</a></td>
+          <td><a href="/javascript/libs/backbone.js">backbone.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="/javascript/libs/bootstrap-lightbox.js">bootstrap-lightbox.js</a></td>
+          <td><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache 2.0</a></td>
+          <td><a href="/javascript/libs/bootstrap-lightbox.js">bootstrap-lightbox.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="/javascript/libs/bootstrap-lightbox.min.js">bootstrap-lightbox.min.js</a></td>
+          <td><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache 2.0</a></td>
+          <td><a href="/javascript/libs/bootstrap-lightbox.js">bootstrap-lightbox.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="/javascript/libs/bootstrap.js">bootstrap.js</a></td>
+          <td><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache 2.0</a></td>
+          <td><a href="/javascript/libs/bootstrap.js">bootstrap.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="/javascript/libs/bootstrap.min.js">bootstrap.min.js</a></td>
+          <td><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache 2.0</a></td>
+          <td><a href="/javascript/libs/bootstrap.js">bootstrap.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="/javascript/libs/jquery-1.10.2.js">jquery-1.10.2.js</a></td>
+          <td><a href="http://www.jclark.com/xml/copying.txt">MIT license</a></td>
+          <td><a href="/javascript/libs/jquery-1.10.2.js">jquery-1.10.2.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="/javascript/libs/jquery-1.10.2.min.js">jquery-1.10.2.min.js</a></td>
+          <td><a href="http://www.jclark.com/xml/copying.txt">MIT license</a></td>
+          <td><a href="/javascript/libs/jquery-1.10.2.js">jquery-1.10.2.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="/javascript/libs/jquery.easydate-0.2.4.js">jquery.easydate-0.2.4.js</a></td>
+          <td><a href="http://www.jclark.com/xml/copying.txt">MIT license</a></td>
+          <td><a href="/javascript/libs/jquery.easydate-0.2.4.js">jquery.easydate-0.2.4.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="/javascript/libs/jquery.easydate-0.2.4.min.js">jquery.easydate-0.2.4.min.js</a></td>
+          <td><a href="http://www.jclark.com/xml/copying.txt">MIT license</a></td>
+          <td><a href="/javascript/libs/jquery.easydate-0.2.4.js">jquery.easydate-0.2.4.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="/javascript/libs/jquery.fineuploader.js">jquery.fineuploader.js</a></td>
+          <!-- According to https://github.com/Valums-File-Uploader/file-uploader/blob/master/license.txt -->
+          <td><a href="http://www.gnu.org/licenses/lgpl-2.1.html">GNU LGPL 2 or later</a></td>
+          <td><a href="/javascript/libs/jquery.fineuploader.js">jquery.fineuploader.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="/javascript/libs/jquery.fineuploader.min.js">jquery.fineuploader.min.js</a></td>
+          <!-- According to https://github.com/Valums-File-Uploader/file-uploader/blob/master/license.txt -->
+          <td><a href="http://www.gnu.org/licenses/lgpl-2.1.html">GNU LGPL 2 or later</a></td>
+          <td><a href="/javascript/libs/jquery.fineuploader.js">jquery.fineuploader.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="/javascript/libs/json2.js">json2.js</a></td>
+          <td><a href="magnet:?xt=urn:btih:e95b018ef3580986a04669f1b5879592219e2a7a&dn=public-domain.txt">Public Domain</a></td>
+          <td><a href="/javascript/libs/json2.js">json2.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="/javascript/libs/json2.min.js">json2.min.js</a></td>
+          <td><a href="magnet:?xt=urn:btih:e95b018ef3580986a04669f1b5879592219e2a7a&dn=public-domain.txt">Public Domain</a></td>
+          <td><a href="/javascript/libs/json2.js">json2.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="/javascript/libs/modernizr-latest.js">modernizr-latest.js</a></td>
+          <td><a href="http://www.jclark.com/xml/copying.txt">MIT license</a></td>
+          <td><a href="/javascript/libs/modernizr-latest.js">modernizr-latest.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="/javascript/libs/oauth.js">oauth.js</a></td>
+          <td><a href="http://www.jclark.com/xml/copying.txt">MIT license</a></td>
+          <td><a href="/javascript/libs/oauth.js">oauth.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="/javascript/libs/oauth.min.js">oauth.min.js</a></td>
+          <td><a href="http://www.jclark.com/xml/copying.txt">MIT license</a></td>
+          <td><a href="/javascript/libs/oauth.js">oauth.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="/javascript/libs/select2.js">select2.js</a></td>
+          <td><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache 2.0 or GPLv2 dual license</a></td>
+          <td><a href="/javascript/libs/select2.js">select2.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="/javascript/libs/select2.min.js">select2.min.js</a></td>
+          <td><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache 2.0 or GPLv2 dual license</a></td>
+          <td><a href="/javascript/libs/select2.js">select2.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="/javascript/libs/sha1.js">sha1.js</a></td>
+          <!-- In http://pajhome.org.uk/site/legal.html#bsdlicense placed BSD 3-Clause License text,
+               where word "copyright holder" replaced with "author" -->
+          <td><a href="http://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause License</a></td>
+          <td><a href="/javascript/libs/sha1.js">sha1.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="/javascript/libs/sha1.min.js">sha1.min.js</a></td>
+          <!-- In http://pajhome.org.uk/site/legal.html#bsdlicense placed BSD 3-Clause License text,
+               where word "copyright holder" replaced with "author" -->
+          <td><a href="http://opensource.org/licenses/BSD-3-Clause">BSD 3-Clause License</a></td>
+          <td><a href="/javascript/libs/sha1.js">sha1.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="/javascript/libs/sockjs.js">sockjs.js</a></td>
+          <td><a href="http://www.jclark.com/xml/copying.txt">MIT license</a></td>
+          <td><a href="/javascript/libs/sockjs.js">sockjs.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="/javascript/libs/sockjs.min.js">sockjs.min.js</a></td>
+          <td><a href="http://www.jclark.com/xml/copying.txt">MIT license</a></td>
+          <td><a href="/javascript/libs/sockjs.js">sockjs.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="/javascript/libs/spin.js">spin.js</a></td>
+          <td><a href="http://www.jclark.com/xml/copying.txt">MIT license</a></td>
+          <td><a href="/javascript/libs/spin.js">spin.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="/javascript/libs/spin.min.js">spin.min.js</a></td>
+          <td><a href="http://www.jclark.com/xml/copying.txt">MIT license</a></td>
+          <td><a href="/javascript/libs/spin.js">spin.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="/javascript/libs/wysihtml5-0.3.0.js">wysihtml5-0.3.0.js</a></td>
+          <td><a href="http://www.jclark.com/xml/copying.txt">MIT license</a></td>
+          <td><a href="/javascript/libs/wysihtml5-0.3.0.js">wysihtml5-0.3.0.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="/javascript/libs/wysihtml5-0.3.0.min.js">wysihtml5-0.3.0.min.js</a></td>
+          <td><a href="http://www.jclark.com/xml/copying.txt">MIT license</a></td>
+          <td><a href="/javascript/libs/wysihtml5-0.3.0.js">wysihtml5-0.3.0.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="/javascript/libs/bootstrap-wysihtml5.js">bootstrap-wysihtml5.js</a></td>
+          <!-- Seems like copy of https://raw.github.com/jhollingworth/bootstrap-wysihtml5/master/src/bootstrap-wysihtml5.js file
+               licensed under https://github.com/jhollingworth/bootstrap-wysihtml5/blob/master/LICENCE -->
+          <td><a href="http://www.jclark.com/xml/copying.txt">MIT license</a></td>
+          <td><a href="/javascript/libs/bootstrap-wysihtml5.js">bootstrap-wysihtml5.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="/javascript/libs/jquery-spin.js">jquery-spin.js</a></td>
+          <!-- Seems like code written by E14N itself, so this must be licensed as whole pump.io project -->
+          <td><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache 2.0</a></td>
+          <td><a href="/javascript/libs/jquery-spin.js">jquery-spin.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="/shared/underscore-min.js">underscore-min.js</a></td>
+          <td><a href="http://www.jclark.com/xml/copying.txt">MIT license</a></td>
+          <td><a href="/shared/underscore.js">underscore.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="/shared/underscore.js">underscore.js</a></td>
+          <td><a href="http://www.jclark.com/xml/copying.txt">MIT license</a></td>
+          <td><a href="/shared/underscore.js">underscore.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js">jquery-1.10.2.min.js from ajax.googleapis.com</a></td>
+          <td><a href="http://www.jclark.com/xml/copying.txt">MIT license</a></td>
+          <td><a href="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.js">jquery-1.10.2.js from ajax.googleapis.com</a></td>
+      </tr>
+      <tr>
+          <td><a href="//cdnjs.cloudflare.com/ajax/libs/json2/20121008/json2.min.js">json2.min.js from cdnjs.cloudflare.com</a></td>
+          <td><a href="magnet:?xt=urn:btih:e95b018ef3580986a04669f1b5879592219e2a7a&amp;dn=public-domain.txt">Public Domain</a></td>
+          <td><a href="//cdnjs.cloudflare.com/ajax/libs/json2/20121008/json2.js">json2.js from cdnjs.cloudflare.com</a></td>
+      </tr>
+      <tr>
+          <td><a href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/2.3.2/js/bootstrap.min.js">bootstrap.min.js from cdnjs.cloudflare.com</a></td>
+          <td><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache 2.0</a></td>
+          <td><a href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/2.3.2/js/bootstrap.js">bootstrap.js from cdnjs.cloudflare.com</a></td>
+      </tr>
+      <tr>
+          <td><a href="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.4.4/underscore-min.js">underscore-min.js from cdnjs.cloudflare.com</a></td>
+          <td><a href="http://www.jclark.com/xml/copying.txt">MIT license</a></td>
+          <td><a href="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.4.4/underscore.js">underscore.js from cdnjs.cloudflare.com</a></td>
+      </tr>
+      <tr>
+          <td><a href="//cdnjs.cloudflare.com/ajax/libs/backbone.js/1.0.0/backbone-min.js">backbone-min.js from cdnjs.cloudflare.com</a></td>
+          <td><a href="http://www.jclark.com/xml/copying.txt">MIT license</a></td>
+          <td><a href="//cdnjs.cloudflare.com/ajax/libs/backbone.js/1.0.0/backbone.js">backbone.js from cdnjs.cloudflare.com</a></td>
+      </tr>
+      <tr>
+          <td><a href="//cdnjs.cloudflare.com/ajax/libs/spin.js/1.2.7/spin.min.js">spin.min.js from cdnjs.cloudflare.com</a></td>
+          <td><a href="http://www.jclark.com/xml/copying.txt">MIT license</a></td>
+          <!-- there is no spin.js v1.2.7 source code on cloudflare. Original source is -->
+          <td><a href="https://github.com/fgnass/spin.js/raw/85275f5fe82ba816b80f1155a96f08884cf98fbb/spin.js">spin.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="//cdnjs.cloudflare.com/ajax/libs/file-uploader/3.1.1/jquery.fineuploader.min.js">jquery.fineuploader.min.js from cdnjs.cloudflare.com</a></td>
+          <!-- According to https://github.com/Valums-File-Uploader/file-uploader/blob/master/license.txt -->
+          <td><a href="http://www.gnu.org/licenses/lgpl-2.1.html">GNU LGPL 2 or later</a></td>
+          <td><a href="//cdnjs.cloudflare.com/ajax/libs/file-uploader/3.1.1/jquery.fineuploader.js">jquery.fineuploader.js from cdnjs.cloudflare.com</a></td>
+      </tr>
+      <tr>
+          <td><a href="//cdnjs.cloudflare.com/ajax/libs/wysihtml5/0.3.0/wysihtml5.min.js">wysihtml5-0.3.0.min.js from  from cdnjs.cloudflare.com</a></td>
+          <td><a href="http://www.jclark.com/xml/copying.txt">MIT license</a></td>
+          <!-- there is no wysihtml5-0.3.0.js source code on cloudflare. Original source is -->
+          <td><a href="https://github.com/xing/wysihtml5/raw/0.3.0/dist/wysihtml5-0.3.0.js">wysihtml5-0.3.0.js</a></td>
+      </tr>
+      <tr>
+          <td><a href="//cdnjs.cloudflare.com/ajax/libs/select2/3.4.1/select2.min.js">select2.min.js from  from cdnjs.cloudflare.com</a></td>
+          <td><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache 2.0 or GPLv2 dual license</a></td>
+          <td><a href="//cdnjs.cloudflare.com/ajax/libs/select2/3.4.1/select2.js">select2.js from  from cdnjs.cloudflare.com</a></td>
+      </tr>
+      <tr>
+          <td><a href="//cdnjs.cloudflare.com/ajax/libs/sockjs-client/0.3.2/sockjs-min.js">sockjs-min.js from  from cdnjs.cloudflare.com</a></td>
+          <td><a href="http://www.jclark.com/xml/copying.txt">MIT license</a></td>
+          <!-- there is no sock.js v0.3.2 source code on cloudflare. Original source is -->
+          <td><a href="https://github.com/sockjs/sockjs-client/tree/v0.3.2/">sockjs.js source code</a></td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/public/javascript/pump.js
+++ b/public/javascript/pump.js
@@ -2,6 +2,9 @@
 //
 // Entrypoint for the pump.io client UI
 //
+// @licstart  The following is the entire license notice for the
+//  JavaScript code in this page.
+//
 // Copyright 2011-2012, E14N https://e14n.com/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +18,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// @licend  The above is the entire license notice
+// for the JavaScript code in this page.
 
 // Make sure this exists
 

--- a/public/javascript/pump/auth.js
+++ b/public/javascript/pump/auth.js
@@ -2,6 +2,9 @@
 //
 // OAuth authentication mechanism for the pump.io client UI
 //
+// @licstart  The following is the entire license notice for the
+//  JavaScript code in this page.
+//
 // Copyright 2011-2012, E14N https://e14n.com/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +18,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// @licend  The above is the entire license notice
+// for the JavaScript code in this page.
 
 (function(_, $, Backbone, Pump) {
 

--- a/public/javascript/pump/model.js
+++ b/public/javascript/pump/model.js
@@ -4,6 +4,9 @@
 //
 // Copyright 2011-2012, E14N https://e14n.com/
 //
+// @licstart  The following is the entire license notice for the
+//  JavaScript code in this page.
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,6 +18,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// @licend  The above is the entire license notice
+// for the JavaScript code in this page.
 
 (function(_, $, Backbone, Pump) {
 

--- a/public/javascript/pump/router.js
+++ b/public/javascript/pump/router.js
@@ -2,6 +2,9 @@
 //
 // Backbone router for the pump.io client UI
 //
+// @licstart  The following is the entire license notice for the
+//  JavaScript code in this page.
+//
 // Copyright 2011-2012, E14N https://e14n.com/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +18,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// @licend  The above is the entire license notice
+// for the JavaScript code in this page.
 
 (function(_, $, Backbone, Pump) {
 

--- a/public/javascript/pump/socket.js
+++ b/public/javascript/pump/socket.js
@@ -2,6 +2,9 @@
 //
 // Socket module for the pump.io client UI
 //
+// @licstart  The following is the entire license notice for the
+//  JavaScript code in this page.
+//
 // Copyright 2011-2012, E14N https://e14n.com/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +18,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// @licend  The above is the entire license notice
+// for the JavaScript code in this page.
 
 (function(_, $, Backbone, Pump) {
 

--- a/public/javascript/pump/view.js
+++ b/public/javascript/pump/view.js
@@ -2,6 +2,9 @@
 //
 // Views for the pump.io client UI
 //
+// @licstart  The following is the entire license notice for the
+//  JavaScript code in this page.
+//
 // Copyright 2011-2013, E14N https://e14n.com/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +18,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// @licend  The above is the entire license notice
+// for the JavaScript code in this page.
 
 // XXX: this needs to be broken up into 3-4 smaller modules
 

--- a/public/template/layout.utml
+++ b/public/template/layout.utml
@@ -134,29 +134,7 @@
     <% }); %>
 
     <script>
-      /*
-      @source See at http://pump.io
-
-      @licstart  The following is the entire license notice for the
-      JavaScript code in this page.
-
-      Copyright 2014, E14N https://e14n.com/
-
-      Licensed under the Apache License, Version 2.0 (the "License");
-      you may not use this file except in compliance with the License.
-      You may obtain a copy of the License at
-
-          http://www.apache.org/licenses/LICENSE-2.0
-
-      Unless required by applicable law or agreed to in writing, software
-      distributed under the License is distributed on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-      See the License for the specific language governing permissions and
-      limitations under the License.
-
-      @licend  The above is the entire license notice
-      for the JavaScript code in this page.
-      */
+      /* @license magnet:?xt=urn:btih:8e4f440f4c65981c5bf93c76d35135ba5064d8b7&dn=apache-2.0.txt Apache-2.0 */
       if (!Pump) {
           Pump = {};
       }
@@ -191,6 +169,7 @@
       Pump.principalUser = null;
       <% } %>
 
+      /* @license-end */
     </script>
   </body>
 

--- a/public/template/layout.utml
+++ b/public/template/layout.utml
@@ -63,6 +63,7 @@
         <p><b><%- config.site %></b> brought to you by <% if (config.ownerURL) { %><a href="<%- config.ownerURL %>"><% } %><%- config.owner %><% if (config.ownerURL) { %></a><% } %>.</p>
         <% } %>
         <p><a href="http://pump.io/">pump.io</a> available under the Apache License 2.0.</p>
+        <p><a href="/javascript/about.html" data-jslicense="1">JavaScript license information</a></p>
       </footer>
 
     </div> <!-- .container -->
@@ -133,6 +134,29 @@
     <% }); %>
 
     <script>
+      /*
+      @source See at http://pump.io
+
+      @licstart  The following is the entire license notice for the
+      JavaScript code in this page.
+
+      Copyright 2014, E14N https://e14n.com/
+
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
+      @licend  The above is the entire license notice
+      for the JavaScript code in this page.
+      */
       if (!Pump) {
           Pump = {};
       }


### PR DESCRIPTION
For client javascript code written by E14N add stylized comments around license notice. For 3rd party code verbatim copied from other projects create JavaScript Web Labels table and keep scripts code unchanged.

With this changes [LibreJS](https://www.gnu.org/software/librejs/) plugin would not block scripts on pump.io servers.