### PR TITLE
Bump simplesmtp version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "node-mocks-http": "0.0.x",
         "zombie": "1.4.x",
         "xml2js": "0.1.x",
-        "simplesmtp": "0.1.x",
+        "simplesmtp": "0.3.x",
         "rimraf": "2.0.x"
     },
     "dependencies": { "connect": "1.x",


### PR DESCRIPTION
This is to fix some failing tests. It's a dirty hack, since simplesmtp is obsolete, but it'll work for now while we have bigger issues.