### PR TITLE
debug

### DIFF
--- a/bin/pump
+++ b/bin/pump
@@ -101,6 +101,16 @@ var launchApps = function(config) {
 
         Dispatch.start(log);
 
+        if (_(config).has("debug")) {
+            debug = config.debug;
+            // for debugging
+            var fixedExecArgv=[];
+            fixedExecArgv.push(debug);
+            cluster.setupMaster({ 
+                execArgv: fixedExecArgv 
+            });
+        }
+        
         for (i = 0; i < cnt; i++) {
             cluster.fork();
         }


### PR DESCRIPTION
This enables debugging  for the forked processes.

Usage :

In your pump.io.json add the following

    "debug" : "--debug-brk=5859",

also set the child processes to one 

    "children":  1,

Then  run 

   node-debug bin/pump -c pump.io.json

Connect to the debugger
http://127.0.0.1:8080/?ws=127.0.0.1:8080&port=5858

Wait for the fork and switch to the child process
http://127.0.0.1:8080/?ws=127.0.0.1:8080&port=5859

See http://stackoverflow.com/a/15578045/782168

 