### PR TITLE
Add missing { to a dictionary definition

### DIFF
--- a/public/template/major-activity-page.utml
+++ b/public/template/major-activity-page.utml
@@ -1,3 +1,3 @@
 <div class="span9" class="major-activity-page">
-  <%= partial("major-activity", headless: false}) %>
+  <%= partial("major-activity", {headless: false}) %>
 </div>


### PR DESCRIPTION
all the other calls to partial with headless: false are formatted as {headless: false}. So add missing {