### PR TITLE
Add the Content-Length to dialback posting client

### DIFF
--- a/lib/dialback.js
+++ b/lib/dialback.js
@@ -95,7 +95,8 @@ var postToEndpoint = function(endpoint, params, callback) {
 
     options.method = "POST";
     options.headers = {
-        "Content-Type": "application/x-www-form-urlencoded"
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Content-Length": pstring.length
     };
 
     var mod = (options.protocol == "https:") ? https : http;


### PR DESCRIPTION
When dialback requests are made by pump, it doesn't include the Content-Length. This adds the Content-Length HTTP header to those requests.