### PR TITLE
Fix for #819, take two

### DIFF
--- a/lib/model/activity.js
+++ b/lib/model/activity.js
@@ -1116,8 +1116,8 @@ Activity.makeContent = function(props) {
 
     var content,
         nameOf = function(obj) {
-            if (_.has(obj, "displayName")) {
-                return obj.displayName;
+            if (_.has(obj, "displayName") && obj.displayName.length > 0) {
+                return obj.displayName; // Only if it's not an empty string!
             } else if (!_.has(obj, "objectType")) {
                 return "an object";
             } else if (["a", "e", "i", "o", "u"].indexOf(obj.objectType[0]) !== -1) {


### PR DESCRIPTION
A simple fix for #819. It can probably be made in a more elegant way, but this one seems to work well.

It just checks that the string in 'displayName' is not empty, because if it is, activities descriptions regarding the "null-named" object get broken.

Up to date version, instead of PR #1126.