### PR TITLE
Extending plugins functionality (two extra functions)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ node_modules
 npm-debug.log
 
 config.js
+pump.io.json

--- a/lib/app.js
+++ b/lib/app.js
@@ -131,6 +131,9 @@ var makeApp = function(configBase, callback) {
     _.each(config.plugins, function(pluginName) {
         log.debug({plugin: pluginName}, "Initializing plugin.");
         plugins[pluginName] = require(pluginName);
+        if (_.isFunction(plugins[pluginName].initializeDb)) {
+            plugins[pluginName].initializeDb(db);
+        }
         if (_.isFunction(plugins[pluginName].initializeLog)) {
             plugins[pluginName].initializeLog(log);
         }
@@ -300,12 +303,19 @@ var makeApp = function(configBase, callback) {
                 app.use(canonicalHost);
             }
 
-            app.use(rawBody);
-
-            app.use(express.bodyParser());
+            app.use(express.methodOverride());
             app.use(express.cookieParser());
             app.use(express.query());
-            app.use(express.methodOverride());
+
+            _.each(plugins, function(plugin, name) {
+                if (_.isFunction(plugin.configureApp)) {
+                    log.debug({plugin: name}, "Configure app.");
+                    plugin.configureApp(app);
+                }
+            });
+
+            app.use(rawBody);
+            app.use(express.bodyParser());
 
             // ^ INPUTTY
             // v OUTPUTTY


### PR DESCRIPTION
Now plugin can have two extra functions:
- `initializeDb()` - a Databank object can be passed to a plugin directly
- `configureApp()` - this method is executed much earlier than `initializeApp()` and allows to configure the app (e.g. add a middleware)